### PR TITLE
android_buildfix: don't link pthread when building for android

### DIFF
--- a/frida-gum-sys/build.rs
+++ b/frida-gum-sys/build.rs
@@ -36,8 +36,10 @@ fn main() {
     #[cfg(not(feature = "auto-download"))]
     println!("cargo:rustc-link-lib=frida-gum");
 
-    #[cfg(any(target_os = "linux", target_os = "macos"))]
-    println!("cargo:rustc-link-lib=pthread");
+     if env::var("CARGO_CFG_TARGET_OS").unwrap() != "android" {
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        println!("cargo:rustc-link-lib=pthread");
+    }
 
     let bindings = bindgen::Builder::default()
         .header("frida-gum.h")

--- a/frida-gum-sys/build.rs
+++ b/frida-gum-sys/build.rs
@@ -36,7 +36,7 @@ fn main() {
     #[cfg(not(feature = "auto-download"))]
     println!("cargo:rustc-link-lib=frida-gum");
 
-     if env::var("CARGO_CFG_TARGET_OS").unwrap() != "android" {
+    if env::var("CARGO_CFG_TARGET_OS").unwrap() != "android" {
         #[cfg(any(target_os = "linux", target_os = "macos"))]
         println!("cargo:rustc-link-lib=pthread");
     }


### PR DESCRIPTION
This fixes an issue when targeting Android.

Note that the target_os check is insufficient, as it runs at BUILD time, not at RUN time...

Please merge and cut a release.