### PR TITLE
Return a capstone-rs Insn instead of the raw cs_insn

### DIFF
--- a/frida-gum/Cargo.toml
+++ b/frida-gum/Cargo.toml
@@ -20,6 +20,7 @@ num-derive = "0.3.3"
 num-traits = "0.2.14"
 paste = "1"
 capstone = "0.8.0"
+capstone-sys = "0.12.0"
 libc = "0.2"
 
 [dev-dependencies]

--- a/frida-gum/Cargo.toml
+++ b/frida-gum/Cargo.toml
@@ -20,7 +20,6 @@ num-traits = "0.2.14"
 paste = "1"
 capstone = "0.8.0"
 capstone-sys = "0.12.0"
-libc = "0.2"
 
 [dev-dependencies]
 lazy_static = "1"

--- a/frida-gum/Cargo.toml
+++ b/frida-gum/Cargo.toml
@@ -9,7 +9,6 @@ description = "Rust bindings for Frida Gum"
 
 [features]
 auto-download = ["frida-gum-sys/auto-download"]
-backtrace = []
 event-sink = ["frida-gum-sys/event-sink"]
 invocation-listener = ["frida-gum-sys/invocation-listener"]
 

--- a/frida-gum/Cargo.toml
+++ b/frida-gum/Cargo.toml
@@ -9,6 +9,7 @@ description = "Rust bindings for Frida Gum"
 
 [features]
 auto-download = ["frida-gum-sys/auto-download"]
+backtrace = []
 event-sink = ["frida-gum-sys/event-sink"]
 invocation-listener = ["frida-gum-sys/invocation-listener"]
 
@@ -18,6 +19,8 @@ num = "0.3.1"
 num-derive = "0.3.3"
 num-traits = "0.2.14"
 paste = "1"
+capstone = "0.8.0"
+libc = "0.2"
 
 [dev-dependencies]
 lazy_static = "1"

--- a/frida-gum/src/stalker/transformer.rs
+++ b/frida-gum/src/stalker/transformer.rs
@@ -5,6 +5,7 @@
  */
 
 use crate::{instruction_writer::TargetInstructionWriter, CpuContext, Gum};
+use capstone::Insn;
 use std::marker::PhantomData;
 use std::os::raw::c_void;
 
@@ -59,7 +60,7 @@ use frida_gum_sys::cs_insn;
 
 pub struct Instruction<'a> {
     parent: *mut frida_gum_sys::GumStalkerIterator,
-    instr: *const cs_insn,
+    instr: Insn<'a>,
     phantom: PhantomData<&'a *const cs_insn>,
 }
 
@@ -70,7 +71,7 @@ impl<'a> Instruction<'a> {
     ) -> Instruction<'a> {
         Instruction {
             parent,
-            instr: instr,
+            instr: unsafe { Insn::from_raw(instr as *const capstone_sys::cs_insn) },
             phantom: PhantomData,
         }
     }
@@ -93,8 +94,8 @@ impl<'a> Instruction<'a> {
         };
     }
 
-    pub fn instr(&self) -> *const cs_insn {
-        self.instr
+    pub fn instr(&self) -> &Insn {
+        &self.instr
     }
 }
 


### PR DESCRIPTION
This PR makes the Instruction.instr() method return a [capstone-rs](https://crates.io/crates/capstone) Insn instead of the raw cs_insn pointer. This makes it much easier to analyze the instruction in the transformer callback.